### PR TITLE
feat: MemoType に基づくキャプチャ画面遷移を実装

### DIFF
--- a/app/src/main/kotlin/cloud/poche/app/navigation/PocheNavHost.kt
+++ b/app/src/main/kotlin/cloud/poche/app/navigation/PocheNavHost.kt
@@ -26,7 +26,9 @@ fun PocheNavHost(
     ) {
         homeScreen(
             onMemoClick = navController::navigateToMemoDetail,
-            onNavigateToCapture = navController::navigateToCapture,
+            onNavigateToCapture = { memoType ->
+                navController.navigateToCapture(memoType = memoType)
+            },
         )
         captureScreen(
             onCaptureComplete = { navController.popBackStack() },

--- a/feature/capture/build.gradle.kts
+++ b/feature/capture/build.gradle.kts
@@ -9,4 +9,5 @@ android {
 
 dependencies {
     implementation(project(":core:data"))
+    implementation(libs.androidx.compose.material.icons.extended)
 }

--- a/feature/capture/src/main/kotlin/cloud/poche/feature/capture/CaptureScreen.kt
+++ b/feature/capture/src/main/kotlin/cloud/poche/feature/capture/CaptureScreen.kt
@@ -1,35 +1,87 @@
 package cloud.poche.feature.capture
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
+import cloud.poche.core.model.MemoType
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun CaptureScreen(
+    memoType: MemoType,
     onCaptureComplete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    CaptureScreenContent(
-        onCaptureComplete = onCaptureComplete,
+    val title = when (memoType) {
+        MemoType.TEXT -> "メモ"
+        MemoType.PHOTO -> "写真"
+        MemoType.VOICE -> "音声メモ"
+    }
+
+    Scaffold(
         modifier = modifier,
-    )
+        topBar = {
+            TopAppBar(
+                title = { Text(title) },
+                navigationIcon = {
+                    IconButton(onClick = onCaptureComplete) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "戻る",
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        when (memoType) {
+            MemoType.TEXT -> MemoCaptureContent(
+                onCaptureComplete = onCaptureComplete,
+                modifier = Modifier.padding(innerPadding),
+            )
+            MemoType.PHOTO -> PlaceholderCaptureContent(
+                icon = Icons.Default.CameraAlt,
+                label = "写真撮影は準備中です",
+                modifier = Modifier.padding(innerPadding),
+            )
+            MemoType.VOICE -> PlaceholderCaptureContent(
+                icon = Icons.Default.Mic,
+                label = "音声録音は準備中です",
+                modifier = Modifier.padding(innerPadding),
+            )
+        }
+    }
 }
 
 @Composable
-private fun CaptureScreenContent(
+private fun MemoCaptureContent(
     onCaptureComplete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -43,16 +95,46 @@ private fun CaptureScreenContent(
         OutlinedTextField(
             value = content,
             onValueChange = { content = it },
-            modifier = Modifier.fillMaxWidth(),
-            label = { Text("メモを入力") },
-            minLines = 5,
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            placeholder = { Text("メモを入力...") },
         )
         Spacer(modifier = Modifier.height(16.dp))
         Button(
             onClick = onCaptureComplete,
             modifier = Modifier.fillMaxWidth(),
+            enabled = content.isNotBlank(),
         ) {
             Text("保存")
         }
+    }
+}
+
+@Composable
+private fun PlaceholderCaptureContent(
+    icon: ImageVector,
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(80.dp),
+            tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }

--- a/feature/capture/src/main/kotlin/cloud/poche/feature/capture/navigation/CaptureNavigation.kt
+++ b/feature/capture/src/main/kotlin/cloud/poche/feature/capture/navigation/CaptureNavigation.kt
@@ -4,20 +4,31 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
+import cloud.poche.core.model.MemoType
 import cloud.poche.feature.capture.CaptureScreen
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object CaptureRoute
+data class CaptureRoute(val memoType: String = MemoType.TEXT.name)
 
-fun NavController.navigateToCapture(navOptions: NavOptions? = null) {
-    navigate(CaptureRoute, navOptions)
+fun NavController.navigateToCapture(
+    memoType: MemoType = MemoType.TEXT,
+    navOptions: NavOptions? = null,
+) {
+    navigate(CaptureRoute(memoType = memoType.name), navOptions)
 }
 
 fun NavGraphBuilder.captureScreen(
     onCaptureComplete: () -> Unit,
 ) {
-    composable<CaptureRoute> {
-        CaptureScreen(onCaptureComplete = onCaptureComplete)
+    composable<CaptureRoute> { backStackEntry ->
+        val route = backStackEntry.toRoute<CaptureRoute>()
+        val memoType = runCatching { MemoType.valueOf(route.memoType) }
+            .getOrDefault(MemoType.TEXT)
+        CaptureScreen(
+            memoType = memoType,
+            onCaptureComplete = onCaptureComplete,
+        )
     }
 }

--- a/feature/home/src/main/kotlin/cloud/poche/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/cloud/poche/feature/home/HomeScreen.kt
@@ -7,48 +7,50 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.NoteAdd
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cloud.poche.core.model.Memo
 import cloud.poche.core.model.MemoType
 import cloud.poche.core.ui.MemoCard
 import cloud.poche.feature.home.component.CaptureActionSheet
 import cloud.poche.feature.home.component.QuickCaptureBar
-import kotlinx.coroutines.launch
 
 @Composable
 internal fun HomeScreen(
     onMemoClick: (String) -> Unit,
-    onNavigateToCapture: () -> Unit,
+    onNavigateToCapture: (MemoType) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
-    val scope = rememberCoroutineScope()
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
@@ -67,11 +69,13 @@ internal fun HomeScreen(
         onMemoClick = onMemoClick,
         onDeleteMemo = viewModel::deleteMemo,
         onQuickCapture = viewModel::quickCapture,
+        onRetry = viewModel::retry,
         onNavigateToCapture = onNavigateToCapture,
         modifier = modifier,
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun HomeScreen(
     uiState: HomeUiState,
@@ -79,13 +83,20 @@ internal fun HomeScreen(
     onMemoClick: (String) -> Unit,
     onDeleteMemo: (String) -> Unit,
     onQuickCapture: (String) -> Unit,
-    onNavigateToCapture: () -> Unit,
+    onRetry: () -> Unit,
+    onNavigateToCapture: (MemoType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var showActionSheet by rememberSaveable { mutableStateOf(false) }
 
-    Box(modifier = modifier.fillMaxSize()) {
-        Column(modifier = Modifier.fillMaxSize()) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(title = { Text("Poche") })
+        },
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+    ) { innerPadding ->
+        Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
             Box(modifier = Modifier.weight(1f)) {
                 when (uiState) {
                     is HomeUiState.Loading -> {
@@ -108,12 +119,10 @@ internal fun HomeScreen(
                         }
                     }
                     is HomeUiState.Error -> {
-                        Box(
-                            modifier = Modifier.fillMaxSize(),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Text(text = uiState.message)
-                        }
+                        ErrorState(
+                            message = uiState.message,
+                            onRetry = onRetry,
+                        )
                     }
                 }
             }
@@ -124,11 +133,6 @@ internal fun HomeScreen(
                 isLoading = uiState is HomeUiState.Loading,
             )
         }
-
-        SnackbarHost(
-            hostState = snackbarHostState,
-            modifier = Modifier.align(Alignment.BottomCenter),
-        )
     }
 
     if (showActionSheet) {
@@ -136,7 +140,7 @@ internal fun HomeScreen(
             onDismiss = { showActionSheet = false },
             onSelected = { type ->
                 showActionSheet = false
-                onNavigateToCapture()
+                onNavigateToCapture(type)
             },
         )
     }
@@ -167,6 +171,30 @@ private fun EmptyState(modifier: Modifier = Modifier) {
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
             )
+        }
+    }
+}
+
+@Composable
+private fun ErrorState(
+    message: String,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.error,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = onRetry) {
+                Text(text = "再試行")
+            }
         }
     }
 }

--- a/feature/home/src/main/kotlin/cloud/poche/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/cloud/poche/feature/home/HomeViewModel.kt
@@ -10,19 +10,23 @@ import cloud.poche.core.domain.usecase.SaveMemoUseCase
 import cloud.poche.core.model.Memo
 import cloud.poche.core.model.MemoType
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.util.UUID
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    getMemosUseCase: GetMemosUseCase,
+    private val getMemosUseCase: GetMemosUseCase,
     private val deleteMemoUseCase: DeleteMemoUseCase,
     private val saveMemoUseCase: SaveMemoUseCase,
 ) : ViewModel() {
@@ -30,23 +34,32 @@ class HomeViewModel @Inject constructor(
     private val _events = MutableSharedFlow<HomeEvent>()
     val events = _events.asSharedFlow()
 
+    private val retryTrigger = MutableStateFlow(0)
+
     val uiState: StateFlow<HomeUiState> =
-        getMemosUseCase()
-            .asResult()
-            .map { result ->
-                when (result) {
-                    is Result.Loading -> HomeUiState.Loading
-                    is Result.Success -> HomeUiState.Success(memos = result.data)
-                    is Result.Error -> HomeUiState.Error(
-                        message = result.exception.message ?: "不明なエラー",
-                    )
-                }
+        retryTrigger
+            .flatMapLatest {
+                getMemosUseCase()
+                    .asResult()
+                    .map { result ->
+                        when (result) {
+                            is Result.Loading -> HomeUiState.Loading
+                            is Result.Success -> HomeUiState.Success(memos = result.data)
+                            is Result.Error -> HomeUiState.Error(
+                                message = result.exception.message ?: "不明なエラー",
+                            )
+                        }
+                    }
             }
             .stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(5_000),
                 initialValue = HomeUiState.Loading,
             )
+
+    fun retry() {
+        retryTrigger.value++
+    }
 
     fun deleteMemo(id: String) {
         viewModelScope.launch {

--- a/feature/home/src/main/kotlin/cloud/poche/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/kotlin/cloud/poche/feature/home/navigation/HomeNavigation.kt
@@ -4,6 +4,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import cloud.poche.core.model.MemoType
 import cloud.poche.feature.home.HomeScreen
 import kotlinx.serialization.Serializable
 
@@ -16,7 +17,7 @@ fun NavController.navigateToHome(navOptions: NavOptions? = null) {
 
 fun NavGraphBuilder.homeScreen(
     onMemoClick: (String) -> Unit,
-    onNavigateToCapture: () -> Unit,
+    onNavigateToCapture: (MemoType) -> Unit,
 ) {
     composable<HomeRoute> {
         HomeScreen(


### PR DESCRIPTION
## Why

HomeScreen から CaptureScreen へ遷移する際、メモの種類 (テキスト/写真/音声) が区別されておらず、常にテキストメモのキャプチャ画面が表示されていた。ユーザーが選択した MemoType に応じた適切なキャプチャ体験を提供するため、型安全なナビゲーションパラメータの導入が必要だった。

## What

- HomeScreen から CaptureScreen への MemoType パラメータ付きナビゲーションを追加
- `CaptureRoute` を `data object` から `data class` に変更し、`memoType` パラメータを追加
- CaptureScreen を MemoType 別に分岐表示 (テキスト / 写真プレースホルダー / 音声プレースホルダー)
- HomeScreen に `Scaffold` + `TopAppBar` を導入し画面構成を改善
- `SnackbarHost` を `Scaffold` 内に移動し適切な配置に修正
- HomeViewModel に `retry()` 機能を追加しエラー時の再試行を可能に
- `ErrorState` コンポーネントを追加しエラー表示を改善

## How

- `CaptureRoute` に `memoType: String` パラメータを追加し、Compose Navigation の型安全ルーティングで MemoType を受け渡し
- `retryTrigger: MutableStateFlow<Int>` と `flatMapLatest` を組み合わせ、ViewModel の再購読による retry 機構を実現
- 写真・音声キャプチャは `PlaceholderCaptureContent` で準備中 UI を表示し、段階的な機能追加に対応