### PR TITLE
fix(app): ステータスバーとタイトル間の余分なスペースを修正

### DIFF
--- a/app/src/main/kotlin/cloud/poche/app/MainActivity.kt
+++ b/app/src/main/kotlin/cloud/poche/app/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -67,6 +68,7 @@ fun PocheApp() {
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         bottomBar = {
             if (showBottomBar) {
                 NavigationBar {


### PR DESCRIPTION
## Why

全画面でステータスバーとタイトルの間に余分なスペースが表示されていた。原因は、`PocheApp` の外側の `Scaffold` が `innerPadding` でステータスバーの insets を適用し、各 feature 画面の `TopAppBar` もデフォルトでステータスバーの insets を適用していたため、二重に適用されていた。

## What

- `PocheApp` の `Scaffold` に `contentWindowInsets = WindowInsets(0, 0, 0, 0)` を設定し、外側の Scaffold でのステータスバー insets 適用を無効化
- 各画面の `TopAppBar` が自身の insets を正しく処理する構成に変更

## How

`app/src/main/kotlin/cloud/poche/app/MainActivity.kt` の `Scaffold` に `contentWindowInsets` パラメータを追加し、全方向のインセットを `0` に設定することで、外側の Scaffold がステータスバーの余白を追加しないようにした。