### PR TITLE
ci: Renovate による依存関係自動更新を設定

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices"
+  ],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["before 9am on monday"],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Kotlin + Compose Compiler",
+      "groupName": "Kotlin",
+      "matchPackagePrefixes": ["org.jetbrains.kotlin"]
+    },
+    {
+      "description": "KSP",
+      "groupName": "KSP",
+      "matchPackagePrefixes": ["com.google.devtools.ksp"]
+    },
+    {
+      "description": "AndroidX Compose (BOM-managed)",
+      "groupName": "AndroidX Compose",
+      "matchPackagePatterns": ["^androidx\\.compose"]
+    },
+    {
+      "description": "AndroidX non-Compose",
+      "groupName": "AndroidX",
+      "matchPackagePrefixes": ["androidx."],
+      "excludePackagePatterns": ["^androidx\\.compose", "^androidx\\.room"]
+    },
+    {
+      "description": "Room",
+      "groupName": "Room",
+      "matchPackagePrefixes": ["androidx.room"]
+    },
+    {
+      "description": "Hilt / Dagger",
+      "groupName": "Hilt",
+      "matchPackagePrefixes": ["com.google.dagger"]
+    },
+    {
+      "description": "Firebase (BOM-managed)",
+      "groupName": "Firebase",
+      "matchPackagePrefixes": ["com.google.firebase", "com.google.gms"]
+    },
+    {
+      "description": "Ktor",
+      "groupName": "Ktor",
+      "matchPackagePrefixes": ["io.ktor"]
+    },
+    {
+      "description": "Kotlinx (coroutines, serialization)",
+      "groupName": "Kotlinx",
+      "matchPackagePrefixes": ["org.jetbrains.kotlinx"]
+    },
+    {
+      "description": "Coil",
+      "groupName": "Coil",
+      "matchPackagePrefixes": ["io.coil-kt"]
+    },
+    {
+      "description": "Testing",
+      "groupName": "Testing",
+      "matchPackagePrefixes": [
+        "org.junit",
+        "io.mockk",
+        "app.cash.turbine",
+        "androidx.test"
+      ]
+    },
+    {
+      "description": "AGP major updates require manual review",
+      "matchPackagePrefixes": ["com.android.tools.build"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Gradle Wrapper",
+      "matchManagers": ["gradle-wrapper"],
+      "groupName": "Gradle Wrapper"
+    }
+  ]
+}


### PR DESCRIPTION
## チケット

- close #16

## Why

依存関係の脆弱性パッチ適用と最新バージョン追跡を自動化し、メンテナンスコストを削減する。
GitHub Actions の SHA 固定も Renovate が自動管理する。

## What

- `renovate.json` を `config:best-practices` ベースで作成
- 11 グループの `packageRules` で依存関係をグループ化
  - Kotlin, KSP, AndroidX Compose, AndroidX, Room, Hilt, Firebase, Ktor, Kotlinx, Coil, Testing
- AGP メジャーアップデートは自動無効化 (手動レビュー必要)
- `helpers:pinGitHubActionDigests` で Actions SHA 固定を自動管理
- Weekly schedule (月曜朝、JST)

## Where

- `renovate.json`

## Notes

- Renovate App を GitHub Marketplace からリポジトリにインストールする必要あり
- 初回は onboarding PR が自動作成される
- `config:best-practices` には lock file maintenance、abandonment detection も含まれる