### PR TITLE
ci: Gate job パターンと Merge Queue トリガーを導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,12 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
   push:
     branches: [main]
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -160,3 +161,14 @@ jobs:
         continue-on-error: true
         with:
           fail-on-severity: high
+
+  ci-gate:
+    needs: [build-and-test, instrumented-test, dependency-review]
+    if: >-
+      always() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - run: echo "All CI checks passed"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,11 +3,12 @@ name: CodeQL
 on:
   pull_request:
     branches: [main]
+  merge_group:
   schedule:
     - cron: '0 18 * * 0' # Sunday 3:00 JST (18:00 UTC Saturday)
 
 concurrency:
-  group: codeql-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -64,3 +65,14 @@ jobs:
         uses: github/codeql-action/analyze@9792ccaef0455e446c567163589397e8c3ac2e0d # v3
         with:
           category: /language:java-kotlin
+
+  codeql-gate:
+    needs: [analyze]
+    if: >-
+      always() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - run: echo "CodeQL passed"


### PR DESCRIPTION
## チケット

- close #24

## Why

CI パイプラインに gate job がなく、skipped ジョブが "passing" 扱いになる問題がある。
また Merge Queue 未対応のため semantic merge conflict の事前検出ができない。

## What

### ci.yml
- `ci-gate` ジョブ追加: build-and-test, instrumented-test, dependency-review の結果を集約
- `merge_group` トリガー追加 (Merge Queue 対応)
- concurrency グループを `merge_group` 互換に修正

### codeql.yml
- `codeql-gate` ジョブ追加: analyze の結果を集約
- `merge_group` トリガー追加
- concurrency グループを `merge_group` 互換に修正

### Gate job パターン
```yaml
if: >-
  always() &&
  !contains(needs.*.result, 'failure') &&
  !contains(needs.*.result, 'cancelled')
```
- `always()` で確実に実行
- `needs.*.result` の明示的チェックで failure/cancelled を検出
- skipped (dependency-review on push) は許容

## Where

- `.github/workflows/ci.yml`
- `.github/workflows/codeql.yml`

## How

Repository Rulesets で `ci-gate` と `codeql-gate` を Required Status Check に設定し、Merge Queue を有効化する (手動 UI 設定)。

## Notes

- Rulesets 設定は手動 UI 操作が必要 (Settings > Rules > Rulesets)
- Merge Queue は poche-cloud org の Public repo で利用可能
- [actions/runner#3041](https://github.com/actions/runner/issues/3041) の `cancelled()` バグを回避するため `!cancelled()` ではなく明示的 result チェックを使用